### PR TITLE
feat: allow using flake output attributes as arguments

### DIFF
--- a/doc/nixrun.txt
+++ b/doc/nixrun.txt
@@ -21,6 +21,12 @@ Configures the options to be used by the plugin.
 
                                          *nixrun-treesitter* *NixRunTSGrammar*
 
+Syntax: `NixRunTSGrammar <grammarName or flakeref#attrpath>`
+
+- `grammarName` can be any of those listed in
+  `nixpkgs#vimPlugins.nvim-treesitter.builtGrammars`.
+- see |flake-output-attribute| for explaination on `flakeref#attrpath`
+
 Temporarily install a treesitter grammar for this session. After the grammar
 is successfully installed, the buffer must be reloaded using |:edit| for
 treesitter highlighting to take effect.
@@ -29,6 +35,11 @@ treesitter highlighting to take effect.
 <
 
                                                 *nixrun-plugin* *NixRunPlugin*
+
+Syntax: `NixRunPlugin <pluginName or flakeref#attrpath>`
+
+- `pluginName` can be any of those listed in `nixpkgs#vimPlugins`
+- see |flake-output-attribute| for explaination on `flakeref#attrpath`
 
 Temporarily install a plugin for this session. After the plugin is
 successfully installed, mimicking |:packadd|, the following files are sourced:
@@ -44,6 +55,16 @@ Example:
 
 >vim
     NixRunPlugin oil-nvim
+    NixRunPlugin nixpkgs#vimPlugins.oil-nvim
 <
+
+                                                      *flake-output-attribute*
+
+A Flake output attribute is a string in the form of `flakeref#attrpath`, e.g.
+`nixpkgs#vimPlugins.nvim-treesitter`. For more details, see the "Flake output
+attribute" section in `nix --help`.
+
+Note that in within this plugin, `#` is NOT optional - this is to
+differentiate between a flake output attribute and shorthand plugin names.
 
 vim:tw=78:ts=8:sw=4:et:ft=help:norl:

--- a/lua/nixrun/lazy.lua
+++ b/lua/nixrun/lazy.lua
@@ -26,14 +26,18 @@ local function install_plugin(nixExpr, succMsg, failMsg)
 				end
 			end,
 			on_stdout = function(_, data, _)
-				local path = data[1]
-				if not vim.tbl_contains(vim.opt.runtimepath:get(), path) then
-					vim.opt.runtimepath:prepend(path)
+				local pluginPath = data[1]
+				if pluginPath == '' then
+					vim.notify(failMsg .. "something went wrong", vim.log.levels.ERROR)
+					return
+				end
+				if not vim.tbl_contains(vim.opt.runtimepath:get(), pluginPath) then
+					vim.opt.runtimepath:prepend(pluginPath)
 					-- mimics the behavior of :packadd
-					source_dir(path .. '/plugin')
+					source_dir(pluginPath .. '/plugin')
 					-- XXX: I don't know if there's a better way to detect if ft detection is on
 					if vim.fn.exists("#filetypedetect") == 1 then
-						pcall(vim.cmd.source, path .. '/ftdetect/*.vim')
+						pcall(vim.cmd.source, pluginPath .. '/ftdetect/*.vim')
 					end
 					vim.notify(succMsg)
 				end


### PR DESCRIPTION
- fix: error message not showing
- feat: allow flake output attribute as args
- docs: update details regarding flake output attribute arguments
